### PR TITLE
add Converter.change_type, add Reference Converter

### DIFF
--- a/asdf/_block/manager.py
+++ b/asdf/_block/manager.py
@@ -313,6 +313,14 @@ class Manager:
         self.options = OptionsStore(self.blocks)
 
     @property
+    def uri(self):
+        if self._uri is not None:
+            return self._uri
+        if self._write_fd is not None:
+            return self._write_fd.uri
+        return None
+
+    @property
     def blocks(self):
         """
         Get any ReadBlocks that were read from an ASDF file

--- a/asdf/_tests/test_extension.py
+++ b/asdf/_tests/test_extension.py
@@ -609,7 +609,10 @@ def test_converter_proxy():
 
     # Should fail because types must instances of type:
     with pytest.raises(TypeError, match=r"Converter property .* must contain str or type values"):
-        ConverterProxy(MinimumConverter(types=[object()]), extension)
+        # as the code will ignore types if no relevant tags are found
+        # include a tag from this extension to make sure the proxy considers
+        # the types
+        ConverterProxy(MinimumConverter(tags=[extension.tags[0].tag_uri], types=[object()]), extension)
 
 
 def test_get_cached_asdf_extension_list():

--- a/asdf/asdf.py
+++ b/asdf/asdf.py
@@ -472,7 +472,7 @@ class AsdfFile:
         In many cases, it is automatically determined from the file
         handle used to read or write the file.
         """
-        return self._blocks._uri
+        return self._blocks.uri
 
     @property
     def _tag_to_schema_resolver(self):

--- a/asdf/core/_converters/reference.py
+++ b/asdf/core/_converters/reference.py
@@ -1,0 +1,18 @@
+from asdf.extension import Converter
+
+
+class ReferenceConverter(Converter):
+    tags = []
+    types = ["asdf.reference.Reference"]
+
+    def to_yaml_tree(self, obj, tag, ctx):
+        raise NotImplementedError()
+
+    def from_yaml_tree(self, node, tag, ctx):
+        raise NotImplementedError()
+
+    def change_type(self, obj, ctx):
+        from asdf.generic_io import relative_uri
+
+        uri = relative_uri(ctx.url, obj._uri) if ctx.url is not None else obj._uri
+        return {"$ref": uri}

--- a/asdf/core/_extensions.py
+++ b/asdf/core/_extensions.py
@@ -4,6 +4,7 @@ from ._converters.complex import ComplexConverter
 from ._converters.constant import ConstantConverter
 from ._converters.external_reference import ExternalArrayReferenceConverter
 from ._converters.ndarray import NDArrayConverter
+from ._converters.reference import ReferenceConverter
 from ._converters.tree import (
     AsdfObjectConverter,
     ExtensionMetadataConverter,
@@ -23,6 +24,7 @@ CONVERTERS = [
     SoftwareConverter(),
     SubclassMetadataConverter(),
     NDArrayConverter(),
+    ReferenceConverter(),
 ]
 
 

--- a/asdf/extension/_manager.py
+++ b/asdf/extension/_manager.py
@@ -33,22 +33,18 @@ class ExtensionManager:
                 if tag_def.tag_uri not in self._tag_defs_by_tag:
                     self._tag_defs_by_tag[tag_def.tag_uri] = tag_def
             for converter in extension.converters:
-                # If a converter's tags do not actually overlap with
-                # the extension tag list, then there's no reason to
-                # use it.
-                if len(converter.tags) > 0:
-                    for tag in converter.tags:
-                        if tag not in self._converters_by_tag:
-                            self._converters_by_tag[tag] = converter
-                    for typ in converter.types:
-                        if isinstance(typ, str):
-                            if typ not in self._converters_by_type:
-                                self._converters_by_type[typ] = converter
-                        else:
-                            type_class_name = get_class_name(typ, instance=False)
-                            if typ not in self._converters_by_type and type_class_name not in self._converters_by_type:
-                                self._converters_by_type[typ] = converter
-                                self._converters_by_type[type_class_name] = converter
+                for tag in converter.tags:
+                    if tag not in self._converters_by_tag:
+                        self._converters_by_tag[tag] = converter
+                for typ in converter.types:
+                    if isinstance(typ, str):
+                        if typ not in self._converters_by_type:
+                            self._converters_by_type[typ] = converter
+                    else:
+                        type_class_name = get_class_name(typ, instance=False)
+                        if typ not in self._converters_by_type and type_class_name not in self._converters_by_type:
+                            self._converters_by_type[typ] = converter
+                            self._converters_by_type[type_class_name] = converter
 
             validators.update(extension.validators)
 

--- a/asdf/reference.py
+++ b/asdf/reference.py
@@ -11,7 +11,7 @@ from contextlib import suppress
 
 import numpy as np
 
-from . import _types, generic_io, treeutil, util
+from . import generic_io, treeutil, util
 from .util import patched_urllib_parse
 
 __all__ = ["resolve_fragment", "Reference", "find_references", "resolve_references", "make_reference"]
@@ -42,9 +42,7 @@ def resolve_fragment(tree, pointer):
     return tree
 
 
-class Reference(_types._AsdfType):
-    yaml_tag = "tag:yaml.org,2002:map"
-
+class Reference:
     def __init__(self, uri, base_uri=None, asdffile=None, target=None):
         self._uri = uri
         if asdffile is not None:
@@ -104,20 +102,6 @@ class Reference(_types._AsdfType):
 
     def __contains__(self, item):
         return item in self._get_target()
-
-    @classmethod
-    def to_tree(cls, data, ctx):
-        base_uri = None
-        if ctx._blocks._write_fd is not None and ctx._blocks._write_fd.uri is not None:
-            base_uri = ctx._blocks._write_fd.uri
-        elif ctx.uri is not None:
-            base_uri = ctx.uri
-        uri = generic_io.relative_uri(base_uri, data._uri) if base_uri is not None else data._uri
-        return {"$ref": uri}
-
-    @classmethod
-    def validate(cls, data):
-        pass
 
 
 def find_references(tree, ctx):


### PR DESCRIPTION
This is a **draft** PR and is against the source branch for https://github.com/asdf-format/asdf/pull/1537 to help demonstrate what a follow-up PR that moves `asdf.reference.Reference` to a converter might look like. This depends on https://github.com/asdf-format/asdf/pull/1537 because of the use of `select_tag` in the old block code: https://github.com/asdf-format/asdf/blob/b0c9a50e8d3add337e1271369a3bf834925176a4/asdf/block.py#L571
causes the changes in this PR to fail (as we're introducing a type of converter that has no tags).

This PR introduces `Converter.change_type` which allows converters to convert an object to a different type (that will then be handled by a different converter). This allows `ReferenceConverter` to convert `Reference` to a regular dict (that is then serialized without a tag) and would allow downstream packages (like asdf-astropy and stdatamodels) to implement converters for NdarrayMixin and FITS_rec which could defer to the NDArrayConverter. An example of a possible NdarrayMixinConverter is as follows:

```python
class NdarrayMixinConverter(Converter):
    tags = []

    types = ["astropy.table.ndarray_mixin.NdarrayMixin"]

    def to_yaml_tree(self, obj, tag, ctx):
        raise NotImplementedError()

    def from_yaml_tree(self, node, tag, ctx):
        raise NotImplementedError()

    def change_type(self, obj, ctx):
        import numpy as np

        return obj.view(np.ndarray)
```

The changes in this PR are similar to https://github.com/asdf-format/asdf/pull/1560 but with the key different being the use of a new `Converter.change_type` method instead of the special `Reconvert` return type. This PR is the now third option for adding a `Reference` converter (with the first being: https://github.com/asdf-format/asdf/pull/1559).